### PR TITLE
change default value of takeUntil linter rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /dist/
 /node_modules/
 .idea
+*.iml

--- a/src/tslint_rules/rxNinjaSubscribeTakeuntilRule.ts
+++ b/src/tslint_rules/rxNinjaSubscribeTakeuntilRule.ts
@@ -49,7 +49,7 @@ export class Rule extends Lint.Rules.TypedRule {
 
     applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
         let ruleArguments = this.getOptions().ruleArguments;
-        const allowedTerminators: string[] = ruleArguments.length === 0 ? ["takeUntil"] : ruleArguments;
+        const allowedTerminators: string[] = ruleArguments.length === 0 ? ["takeUntil", "untilComponentDestroyed"] : ruleArguments;
 
         const failures: Lint.RuleFailure[] = [];
         // let relevantClasses: ts.Node[] = tsquery(sourceFile, "ClassDeclaration");


### PR DESCRIPTION
change default to `["takeUntil", "untilComponentDestroyed"]`