### PR TITLE
chore: remove TypeScript peer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # rx-ninja Changelog
 
+## 6.0.1
+
+* remove the unnecessary TypeScript peer dependency; TypeScript is only used to build rx-ninja, and the published declarations work with TypeScript 6 and 7
+
 ## 6.0.0
 
 * modernize toolchain & dev dependencies (RxJS 7, ESLint 9 flat config + typescript-eslint 8, TypeScript 5.9, Mocha 11, Sinon 22, TypeDoc 0.28, np 11)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@w11k/rx-ninja",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@w11k/rx-ninja",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@swirly/parser": "^0.21.0",
@@ -45,8 +45,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "rxjs": ">=6.0.0",
-        "typescript": "^3 || ^4 || ^5 || ^6"
+        "rxjs": ">=6.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@w11k/rx-ninja",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "license": "Apache-2.0",
   "author": "W11K GmbH",
   "contributors": [
@@ -58,8 +58,7 @@
     "version-bump-prompt": "^5.0.7"
   },
   "peerDependencies": {
-    "rxjs": ">=6.0.0",
-    "typescript": "^3 || ^4 || ^5 || ^6"
+    "rxjs": ">=6.0.0"
   },
   "scripts": {
     "np": "np",


### PR DESCRIPTION
## Summary

- release rx-ninja 6.0.1
- remove the TypeScript peer dependency so consumers are not limited to TypeScript 3-6
- keep RxJS as the only peer dependency

The package ships JavaScript and declaration files and does not use a consuming project's TypeScript compiler at runtime.

## Verification

- build passes
- lint passes
- 109 tests pass
- published declarations compile in fresh consumers with TypeScript 6.0.3 and 7.0.2
- package dry-run passes
- runtime audit reports 0 findings
